### PR TITLE
noticed that calls to "count" style methods were not accepting filter params...

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -80,15 +80,20 @@ Resource.prototype.del = function (params, callback) {
     this.client.del({path:rPath}, callback);
 };
 
-Resource.prototype.count = function(params, callback) {
-    if(!callback) // params is optional
+Resource.prototype.count = function(params, queryParameters, callback) {
+    if (arguments.length == 1 && typeof(params) == 'function')
     {
-        callback = params;
-        params = null;
+      callback = params;
+      params = null;
+    }
+    else if(arguments.length == 2 && typeof(queryParameters) == 'function')
+    {
+      callback = queryParameters;
+      queryParameters = params;
+      params = null;
     }
 
-    var rPath = this.urlPathFromRoute('count', params);
-
+    var rPath = this.urlPathFromRoute('count', params, queryParameters);
     this.client.get(rPath, callback);
 };
 
@@ -100,7 +105,7 @@ Resource.prototype.count = function(params, callback) {
 // - **params** - object which will be used to generate url
 // - **queryParams** - optional object which will be serialized into a query string and appended onto url
 Resource.prototype.urlPathFromRoute = function (routeName, params, queryParams) {
-    var route = this.getRoutes()[routeName];
+    var route = this.getRoutes()[routeName] + this.extension;
 
     if (params) {
         Object.keys(params).forEach(function (key, index, ar) {
@@ -115,7 +120,7 @@ Resource.prototype.urlPathFromRoute = function (routeName, params, queryParams) 
         route = route + '?' + querystring.stringify(queryParams);
     }
 
-    return this.basePath + route + this.extension;
+    return this.basePath + route;
 }
 
 //


### PR DESCRIPTION
...tilized or available -- forced this guy to behave the same as getAll.
- urlPathFromRoute method needs to append .json(extension) before building/appending the rest of the querystring.
